### PR TITLE
docs: update link to guidelines for PR reviewers

### DIFF
--- a/vignettes/RforMassSpectrometry.Rmd
+++ b/vignettes/RforMassSpectrometry.Rmd
@@ -124,7 +124,7 @@ contribution guides for additional resources and instructions.
 
 Reviewers will do their best to help you to get the PR
 merged^[Useful reading: The [nodejs reviewing PRs for
-reviewers](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#reviewing-pull-requests)
+reviewers](https://github.com/nodejs/node/blob/main/doc/contributing/pull-requests.md#reviewing-pull-requests)
 guide].
 
 


### PR DESCRIPTION
Hello there, 
Just spotted that the link to the NodeJS guidelines was broken when I was looking it up, so I  updated it.
Best, 
